### PR TITLE
Update plugins.sbt for scoverage 1.0.4

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,5 +6,5 @@ resolvers ++= Seq(
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.3")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.8.1")
 addSbtPlugin("de.johoop" % "jacoco4sbt" % "2.1.6")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
 


### PR DESCRIPTION
This upgrade to scoverage 1.0.4 will show you which case bodys were not executed. The outer "function" stays green as a whole, as the function itself (the method on Ordering) was entered, but now two of the case bodys are red so you can see where you need to improve.
